### PR TITLE
Clear inputs when start to connect or on error

### DIFF
--- a/TelinkFlasher.html
+++ b/TelinkFlasher.html
@@ -36,6 +36,9 @@ function resetVariables() {
     writeCharacteristic = null;
     miConnected = false;
     is_logged_in = false;
+    document.getElementById("known_id").value = '';
+    document.getElementById("mi_token").value = '';
+    document.getElementById("mi_bind_key").value = '';
 }
 
 function handleError(error) {


### PR DESCRIPTION
If there are many devices, after flashing the first one, a click on "Connect" does not clear the inputs. In some cases (not connected yet to another device, have problem with another device etc.) we think the connect is finished and believe the inputs are update, but it is not. An example is https://github.com/custom-components/ble_monitor/issues/204 that user thought new bind key had been created.

Thus we should clear the inputs every time we try to connect.