### PR TITLE
Allow display to set image data message size

### DIFF
--- a/ATC_GICISKY_Paper_Image_Upload.html
+++ b/ATC_GICISKY_Paper_Image_Upload.html
@@ -536,13 +536,22 @@
             sendcmd("01");
         }
 
+        // will be set based on chunk size requested by display
+        let imagePartSize;
         function img_state_handle(data) {
             switch (data.substring(0, 2)) {
                 case "01":
-                    if (data == "01f400")
-                        sendcmd("02" + intToHex(imgArrayLen / 2) + "000000");
-                    else
-                        addLog("Please reconnect to send a new Image");
+                    // Read image part message size from response bytes 2 & 3 as uint16le
+                    // Typically, this will be 0xf400 = 244d
+                    const imagePartMessageSize =
+                      new DataView(hexToBytes(data).buffer).getUint16(1, true);
+                    console.log(`Display requested image part message size ${imagePartMessageSize}`);
+
+                    // Image part size will be four bytes less than the message size
+                    // to account for the 4 byte uint32le part number starting each message
+                    imagePartSize = imagePartMessageSize - 4;
+
+                    sendcmd("02" + intToHex(imgArrayLen / 2) + "000000");
                     break;
 
                 case "02":
@@ -575,9 +584,9 @@
                 let currentpart = oldPart;
                 console.log("PartACK: " + partAcked + " PartUpload: " + intToHex(uploadPart));
                 if (partAcked == intToHex(uploadPart)) {
-                    currentpart = intToHex(uploadPart) + imgArray.substring(0, 480);
+                    currentpart = intToHex(uploadPart) + imgArray.substring(0, imagePartSize * 2);
                     oldPart = currentpart;
-                    imgArray = imgArray.substring(480);
+                    imgArray = imgArray.substring(imagePartSize * 2);
                     setStatus('Current part: ' + uploadPart);
                     uploadPart++;
                 } else {


### PR DESCRIPTION
Interpret the second and third bytes of the `01` response notification from the display as a uint16le containing the display's requested image data message size.

Prior to this commit, the expected value of the `01` response was `01 f4 00`, and the image part size was hardcoded to 240 bytes. 

Interpreted as a uint16le, `f4 00` = 244d, which is the message size for a 4 byte uint32le part number concatenated to 240 image part data bytes.

Note that I've made an assumption that both bytes should be interpreted as the message size; I've only ever seen the first byte change (to 0x65), so it's possible the size should be read as a uint8 followed by an unknown byte.

This fixes a bug preventing uploading images from Chrome on an older Macbook Air, which received `01 65 00` in response to the control command `01`, while a newer Android device received the expected `01 f4 00` from the same display. 

Forcing the Mac which got `01 65 00` to send 240 byte image data chunks transfers data, but fails to update the display. Sending 97d (= 0x65 - 4) byte chunks from the Mac succeeds in updating the display.

Tested on a 2.9" BWR epaper display with settings:

 - 296x128 BWR
 - No dithering
 - No compression
 - Second color on
 - No mirroring